### PR TITLE
Update email templates with branded HTML

### DIFF
--- a/compose/templates/email_notify.tmpl
+++ b/compose/templates/email_notify.tmpl
@@ -1,6 +1,81 @@
-Hello {{.RecipientName}},
-
-You have a new notification from GoChat.
-
-Thanks,
-The GoChat Team
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Registration Confirmation</title>
+    <style>
+        html, body {
+            font-family: Arial, sans-serif;
+            color: #b9bbbe;
+            background-color: #2c2f33;
+            padding: 20px;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #313338;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+        }
+        .header {
+            text-align: center;
+            padding: 10px 0;
+            background-color: #5865f2;
+            color: #ffffff;
+            border-radius: 10px 10px 0 0;
+        }
+        .content {
+            padding: 20px;
+        }
+        .content h1 {
+            font-size: 24px;
+            color: #ffffff;
+        }
+        .content p {
+            font-size: 16px;
+            line-height: 1.5;
+            color: #b9bbbe;
+        }
+        .footer {
+            text-align: center;
+            padding: 10px;
+            font-size: 12px;
+            color: #72767d;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            font-size: 16px;
+            color: #ffffff;
+            background-color: #7289da;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .button:hover {
+            background-color: #5865f2;
+            color: white;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2>Welcome to {{.AppName}}</h2>
+        </div>
+        <div class="content">
+            <h1>Hello, friend!</h1>
+            <p>Thank you for registering with {{.AppName}}. To complete your registration, please confirm your email address by clicking the button below</p>
+            <p style="text-align: center;">
+                <a href="{{.BaseURL}}/app/confirmation/{{.UserId}}/{{.Token}}" class="button">Confirm Email</a>
+            </p>
+            <p>If you did not sign up for {{.AppName}}, please ignore this email.</p>
+        </div>
+        <div class="footer">
+            <p>&copy; {{.Year}} {{.AppName}}. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/compose/templates/password_reset.tmpl
+++ b/compose/templates/password_reset.tmpl
@@ -1,10 +1,82 @@
-Hello {{.RecipientName}},
-
-We received a request to reset your GoChat password. Use the token below to complete the process:
-
-{{.Token}}
-
-If you did not request this, you can safely ignore this email.
-
-Thanks,
-The GoChat Team
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset</title>
+    <style>
+        html, body {
+            font-family: Arial, sans-serif;
+            color: #b9bbbe;
+            background-color: #2c2f33;
+            padding: 20px;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #313338;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+        }
+        .header {
+            text-align: center;
+            padding: 10px 0;
+            background-color: #5865f2;
+            color: #ffffff;
+            border-radius: 10px 10px 0 0;
+        }
+        .content {
+            padding: 20px;
+        }
+        .content h1 {
+            font-size: 24px;
+            color: #ffffff;
+        }
+        .content p {
+            font-size: 16px;
+            line-height: 1.5;
+            color: #b9bbbe;
+        }
+        .footer {
+            text-align: center;
+            padding: 10px;
+            font-size: 12px;
+            color: #72767d;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            font-size: 16px;
+            color: #ffffff;
+            background-color: #7289da;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .button:hover {
+            background-color: #5865f2;
+            color: white;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2>Password Reset - {{.AppName}}</h2>
+        </div>
+        <div class="content">
+            <h1>Hello!</h1>
+            <p>We received a request to reset your password for your {{.AppName}} account. To reset your password, please click the button below:</p>
+            <p style="text-align: center;">
+                <a href="{{.BaseURL}}/app/recovery/{{.UserId}}/{{.Token}}" class="button">Reset Password</a>
+            </p>
+            <p>If you did not request a password reset, please ignore this email or contact support if you have concerns.</p>
+            <p>This password reset link will expire after 24 hours.</p>
+        </div>
+        <div class="footer">
+            <p>&copy; {{.Year}} {{.AppName}}. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/helm/gochat/values.yaml
+++ b/helm/gochat/values.yaml
@@ -133,23 +133,170 @@ auth:
     # PostgreSQL
     pg_dsn: "host=citus-master port=5432 user=postgres dbname=gochat sslmode=disable"
   emailTemplate: |
-    Hello {{.RecipientName}},
-
-    You have a new notification from GoChat.
-
-    Thanks,
-    The GoChat Team
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Registration Confirmation</title>
+        <style>
+            html, body {
+                font-family: Arial, sans-serif;
+                color: #b9bbbe;
+                background-color: #2c2f33;
+                padding: 20px;
+            }
+            .container {
+                max-width: 600px;
+                margin: 0 auto;
+                background-color: #313338;
+                padding: 20px;
+                border-radius: 10px;
+                box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+            }
+            .header {
+                text-align: center;
+                padding: 10px 0;
+                background-color: #5865f2;
+                color: #ffffff;
+                border-radius: 10px 10px 0 0;
+            }
+            .content {
+                padding: 20px;
+            }
+            .content h1 {
+                font-size: 24px;
+                color: #ffffff;
+            }
+            .content p {
+                font-size: 16px;
+                line-height: 1.5;
+                color: #b9bbbe;
+            }
+            .footer {
+                text-align: center;
+                padding: 10px;
+                font-size: 12px;
+                color: #72767d;
+            }
+            .button {
+                display: inline-block;
+                padding: 10px 20px;
+                font-size: 16px;
+                color: #ffffff;
+                background-color: #7289da;
+                text-decoration: none;
+                border-radius: 5px;
+            }
+            .button:hover {
+                background-color: #5865f2;
+                color: white;
+                text-decoration: none;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <h2>Welcome to {{.AppName}}</h2>
+            </div>
+            <div class="content">
+                <h1>Hello, friend!</h1>
+                <p>Thank you for registering with {{.AppName}}. To complete your registration, please confirm your email address by clicking the button below</p>
+                <p style="text-align: center;">
+                    <a href="{{.BaseURL}}/app/confirmation/{{.UserId}}/{{.Token}}" class="button">Confirm Email</a>
+                </p>
+                <p>If you did not sign up for {{.AppName}}, please ignore this email.</p>
+            </div>
+            <div class="footer">
+                <p>&copy; {{.Year}} {{.AppName}}. All rights reserved.</p>
+            </div>
+        </div>
+    </body>
+    </html>
   passwordResetTemplate: |
-    Hello {{.RecipientName}},
-
-    We received a request to reset your GoChat password. Use the token below to complete the process:
-
-    {{.Token}}
-
-    If you did not request this, you can safely ignore this email.
-
-    Thanks,
-    The GoChat Team
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Password Reset</title>
+        <style>
+            html, body {
+                font-family: Arial, sans-serif;
+                color: #b9bbbe;
+                background-color: #2c2f33;
+                padding: 20px;
+            }
+            .container {
+                max-width: 600px;
+                margin: 0 auto;
+                background-color: #313338;
+                padding: 20px;
+                border-radius: 10px;
+                box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+            }
+            .header {
+                text-align: center;
+                padding: 10px 0;
+                background-color: #5865f2;
+                color: #ffffff;
+                border-radius: 10px 10px 0 0;
+            }
+            .content {
+                padding: 20px;
+            }
+            .content h1 {
+                font-size: 24px;
+                color: #ffffff;
+            }
+            .content p {
+                font-size: 16px;
+                line-height: 1.5;
+                color: #b9bbbe;
+            }
+            .footer {
+                text-align: center;
+                padding: 10px;
+                font-size: 12px;
+                color: #72767d;
+            }
+            .button {
+                display: inline-block;
+                padding: 10px 20px;
+                font-size: 16px;
+                color: #ffffff;
+                background-color: #7289da;
+                text-decoration: none;
+                border-radius: 5px;
+            }
+            .button:hover {
+                background-color: #5865f2;
+                color: white;
+                text-decoration: none;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <h2>Password Reset - {{.AppName}}</h2>
+            </div>
+            <div class="content">
+                <h1>Hello!</h1>
+                <p>We received a request to reset your password for your {{.AppName}} account. To reset your password, please click the button below:</p>
+                <p style="text-align: center;">
+                    <a href="{{.BaseURL}}/app/recovery/{{.UserId}}/{{.Token}}" class="button">Reset Password</a>
+                </p>
+                <p>If you did not request a password reset, please ignore this email or contact support if you have concerns.</p>
+                <p>This password reset link will expire after 24 hours.</p>
+            </div>
+            <div class="footer">
+                <p>&copy; {{.Year}} {{.AppName}}. All rights reserved.</p>
+            </div>
+        </div>
+    </body>
+    </html>
   resources: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## Summary
- replace the notification and password reset templates with the new branded HTML versions in the compose bundle
- update the Helm chart defaults so the same HTML templates are available for customization before deployment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb803760448322843908ffc9595cfc