### PR TITLE
Allow selecting GoChat image variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ This repository contains infrastructure assets for running the GoChat stack eith
    ```
    Update the copied files and adjust the volume mounts inside `compose/docker-compose.yaml` if you want Docker to use the customised versions. The committed files contain default values that allow the stack to boot without additional changes.
 2. Review the Traefik labels in the compose file and update domain names or paths to match your environment.
-3. Start the stack:
+3. (Optional) Choose which GoChat application images to deploy by setting `GOCHAT_IMAGE_VARIANT` to either `latest` (default) or `dev` before running Compose.
+4. Start the stack:
    ```bash
    docker compose -f compose/docker-compose.yaml up -d
    ```
-4. Stop everything when finished:
+5. Stop everything when finished:
    ```bash
    docker compose -f compose/docker-compose.yaml down
    ```
@@ -58,6 +59,7 @@ The Helm chart deploys the same set of services as Docker Compose: ScyllaDB, NAT
 - **Config maps** – API, auth, websocket and indexer services load their YAML configuration from config maps rendered from the values file. Update the relevant `config` blocks to match your infrastructure.
 - **Persistent storage** – Scylla, OpenSearch and Citus master use persistent volume claims by default. Storage class names and sizes are configurable via the `persistence` sections.
 - **Optional components** – Disable services by toggling the `enabled` flag under their respective section. For example, set `traefik.enabled=false` if you already run an ingress controller. Enable Citus workers by setting `citus.worker.enabled=true` and adjusting `replicaCount`.
+- **Image variants** – Set `global.imageVariant` to `latest` (default) or `dev` to control which tag the API, auth, websocket, indexer and UI deployments use. Individual services can still override the `image.tag` field if necessary.
 - **Ingress** – The chart ships with an optional generic ingress definition. Populate the `ingress` block to expose the UI, API or websocket routes through your ingress controller.
 
 Refer to the comments in `helm/gochat/values.yaml` for all available knobs.

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     restart: always
 
   auth:
-    image: ghcr.io/flameinthedark/gochat-auth:latest
+    image: ghcr.io/flameinthedark/gochat-auth:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     volumes:
       - ./config/auth_config.yaml:/dist/config.yaml
@@ -61,7 +61,7 @@ services:
       - default
 
   ui:
-    image: ghcr.io/flameinthedark/gochatui:latest
+    image: ghcr.io/flameinthedark/gochatui:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     labels:
       - "traefik.enable=true"
@@ -80,7 +80,7 @@ services:
       - default
 
   api:
-    image: ghcr.io/flameinthedark/gochat-api:latest
+    image: ghcr.io/flameinthedark/gochat-api:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     volumes:
       - ./config/api_config.yaml:/dist/config.yaml
@@ -104,7 +104,7 @@ services:
       - default
 
   ws:
-    image: ghcr.io/flameinthedark/gochat-ws:latest
+    image: ghcr.io/flameinthedark/gochat-ws:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     volumes:
       - ./config/ws_config.yaml:/dist/config.yaml
@@ -125,7 +125,7 @@ services:
       - default
 
   indexer:
-    image: ghcr.io/flameinthedark/gochat-indexer:latest
+    image: ghcr.io/flameinthedark/gochat-indexer:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     volumes:
       - ./config/indexer_config.yaml:/dist/config.yaml

--- a/helm/gochat/templates/api.yaml
+++ b/helm/gochat/templates/api.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: "{{ .Values.api.image.repository }}:{{ default .Values.global.imageVariant .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.api.service.port }}

--- a/helm/gochat/templates/auth.yaml
+++ b/helm/gochat/templates/auth.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: auth
-          image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag }}"
+          image: "{{ .Values.auth.image.repository }}:{{ default .Values.global.imageVariant .Values.auth.image.tag }}"
           imagePullPolicy: {{ .Values.auth.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.auth.service.port }}

--- a/helm/gochat/templates/indexer.yaml
+++ b/helm/gochat/templates/indexer.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: indexer
-          image: "{{ .Values.indexer.image.repository }}:{{ .Values.indexer.image.tag }}"
+          image: "{{ .Values.indexer.image.repository }}:{{ default .Values.global.imageVariant .Values.indexer.image.tag }}"
           imagePullPolicy: {{ .Values.indexer.image.pullPolicy }}
 {{- if .Values.indexer.env }}
           env:

--- a/helm/gochat/templates/ui.yaml
+++ b/helm/gochat/templates/ui.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: ui
-          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          image: "{{ .Values.ui.image.repository }}:{{ default .Values.global.imageVariant .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.ui.service.port }}

--- a/helm/gochat/templates/ws.yaml
+++ b/helm/gochat/templates/ws.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: ws
-          image: "{{ .Values.ws.image.repository }}:{{ .Values.ws.image.tag }}"
+          image: "{{ .Values.ws.image.repository }}:{{ default .Values.global.imageVariant .Values.ws.image.tag }}"
           imagePullPolicy: {{ .Values.ws.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.ws.service.port }}

--- a/helm/gochat/values.yaml
+++ b/helm/gochat/values.yaml
@@ -1,6 +1,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
+global:
+  imageVariant: latest
+
 imagePullSecrets: []
 
 scylla:
@@ -90,7 +93,7 @@ auth:
   replicaCount: 1
   image:
     repository: ghcr.io/flameinthedark/gochat-auth
-    tag: latest
+    tag: "" # Overrides global.imageVariant when set
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -307,7 +310,7 @@ api:
   replicaCount: 1
   image:
     repository: ghcr.io/flameinthedark/gochat-api
-    tag: latest
+    tag: "" # Overrides global.imageVariant when set
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -361,7 +364,7 @@ ws:
   replicaCount: 1
   image:
     repository: ghcr.io/flameinthedark/gochat-ws
-    tag: latest
+    tag: "" # Overrides global.imageVariant when set
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
@@ -387,7 +390,7 @@ indexer:
   replicaCount: 1
   image:
     repository: ghcr.io/flameinthedark/gochat-indexer
-    tag: latest
+    tag: "" # Overrides global.imageVariant when set
     pullPolicy: IfNotPresent
   env: []
   config: |
@@ -409,7 +412,7 @@ ui:
   replicaCount: 1
   image:
     repository: ghcr.io/flameinthedark/gochatui
-    tag: latest
+    tag: "" # Overrides global.imageVariant when set
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP


### PR DESCRIPTION
## Summary
- allow docker compose deployments to switch GoChat application images between the `latest` and `dev` tags through `GOCHAT_IMAGE_VARIANT`
- add a Helm-wide `global.imageVariant` setting and use it as the default tag for the API, auth, websocket, indexer and UI deployments
- document the new knobs for Docker Compose and Helm users

## Testing
- `helm lint helm/gochat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb81857e5c8322a8180a270a82061d