### PR TITLE
Add landing UI option and automate database migrations

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -56,12 +56,14 @@ services:
         condition: service_started
       citus-master:
         condition: service_started
+      migrations:
+        condition: service_completed_successfully
     networks:
       - traefik
       - default
 
   ui:
-    image: ghcr.io/flameinthedark/gochatui:${GOCHAT_IMAGE_VARIANT:-latest}
+    image: ghcr.io/flameinthedark/${GOCHAT_UI_IMAGE:-gochatui}:${GOCHAT_IMAGE_VARIANT:-latest}
     restart: always
     labels:
       - "traefik.enable=true"
@@ -99,6 +101,8 @@ services:
         condition: service_started
       auth:
         condition: service_started
+      migrations:
+        condition: service_completed_successfully
     networks:
       - traefik
       - default
@@ -134,6 +138,22 @@ services:
         condition: service_started
       opensearch:
         condition: service_started
+
+  migrations:
+    image: golang:1.23-alpine
+    command: ["/bin/sh", "/scripts/run-migrations.sh"]
+    environment:
+      PG_ADDRESS: ${PG_ADDRESS:-postgres://postgres@citus-master:5432/gochat?sslmode=disable}
+      CASSANDRA_ADDRESS: ${CASSANDRA_ADDRESS:-cassandra://scylla:9042/gochat?x-multi-statement=true}
+    volumes:
+      - ./db:/migrations:ro
+      - ./compose/init/run-migrations.sh:/scripts/run-migrations.sh:ro
+    depends_on:
+      scylla:
+        condition: service_healthy
+      citus-master:
+        condition: service_started
+    restart: "no"
 
   opensearch:
     image: opensearchproject/opensearch:2.13.0

--- a/compose/init/run-migrations.sh
+++ b/compose/init/run-migrations.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -z "${PG_ADDRESS:-}" ] && [ -z "${CASSANDRA_ADDRESS:-}" ]; then
+  echo "PG_ADDRESS or CASSANDRA_ADDRESS must be provided" >&2
+  exit 1
+fi
+
+# Install migrate tool with postgres and cassandra support
+apk add --no-cache ca-certificates git build-base >/dev/null
+
+go install -tags "postgres cassandra" github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+MIGRATE_BIN="$(go env GOPATH)/bin/migrate"
+
+if [ -n "${PG_ADDRESS:-}" ]; then
+  ${MIGRATE_BIN} -database "${PG_ADDRESS}" -path /migrations/postgres up
+else
+  echo "Skipping PostgreSQL migrations because PG_ADDRESS is empty"
+fi
+
+if [ -n "${CASSANDRA_ADDRESS:-}" ]; then
+  ${MIGRATE_BIN} -database "${CASSANDRA_ADDRESS}" -path /migrations/cassandra up
+else
+  echo "Skipping Scylla migrations because CASSANDRA_ADDRESS is empty"
+fi

--- a/db/cassandra/000001_initial.down.cql
+++ b/db/cassandra/000001_initial.down.cql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS gochat.messages;
+DROP TABLE IF EXISTS gochat.avatars;
+DROP TABLE IF EXISTS gochat.icons;
+DROP TABLE IF EXISTS gochat.attachments;
+DROP TABLE IF EXISTS gochat.reactions;

--- a/db/cassandra/000001_initial.up.cql
+++ b/db/cassandra/000001_initial.up.cql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS gochat.attachments
+(
+    id           bigint,
+    channel_id   bigint,
+    name         text,
+    filesize     bigint,
+    content_type text,
+    height       bigint,
+    width        bigint,
+    done         boolean,
+    PRIMARY KEY ( (channel_id), id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.icons
+(
+    id       bigint,
+    guild_id bigint,
+    object   text,
+    PRIMARY KEY ( guild_id, id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.avatars
+(
+    id      bigint,
+    user_id bigint,
+    object  text,
+    PRIMARY KEY ( user_id, id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.messages
+(
+    channel_id  bigint,
+    bucket      int,
+    id          bigint,
+    user_id     bigint,
+    content     text,
+    thread_id   bigint,
+    attachments list<bigint>,
+    type        int,
+    reference   bigint,
+    thread      bigint,
+    edited_at   timestamp,
+    PRIMARY KEY ( (channel_id, bucket), id )
+) WITH CLUSTERING ORDER BY (id DESC);
+
+CREATE TABLE IF NOT EXISTS gochat.reactions
+(
+    message_id bigint,
+    user_id    bigint,
+    emote_id   bigint,
+    PRIMARY KEY ( message_id, user_id )
+);

--- a/db/postgres/000001_initial.down.sql
+++ b/db/postgres/000001_initial.down.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS audit;
+DROP TABLE IF EXISTS channel_user_permissions;
+DROP TABLE IF EXISTS channel_roles_permissions;
+DROP TABLE IF EXISTS user_roles;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS members;
+DROP TABLE IF EXISTS group_dm_channels;
+DROP TABLE IF EXISTS dm_channels;
+DROP TABLE IF EXISTS friends;
+DROP TABLE IF EXISTS guild_channels;
+DROP TABLE IF EXISTS channels;
+DROP TABLE IF EXISTS guilds;
+DROP TABLE IF EXISTS discriminators;
+DROP TABLE IF EXISTS registrations;
+DROP TABLE IF EXISTS authentications;
+DROP TABLE IF EXISTS users;

--- a/db/postgres/000001_initial.up.sql
+++ b/db/postgres/000001_initial.up.sql
@@ -1,0 +1,178 @@
+CREATE EXTENSION IF NOT EXISTS citus;
+
+CREATE TABLE users
+(
+    id           BIGINT PRIMARY KEY,
+    name         TEXT        NOT NULL,
+    avatar       BIGINT,
+    blocked      BOOL        NOT NULL,
+    upload_limit BIGINT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_users_id_name ON users (id, name);
+SELECT create_distributed_table('users', 'id');
+
+CREATE TABLE authentications
+(
+    user_id       BIGINT      NOT NULL,
+    email         TEXT        NOT NULL,
+    password_hash TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_authentication_id_email ON authentications (user_id, email);
+SELECT create_distributed_table('authentications', 'user_id');
+
+CREATE TABLE registrations
+(
+    user_id            BIGINT PRIMARY KEY,
+    email              TEXT        NOT NULL,
+    confirmation_token TEXT        NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_registration_user_id ON registrations (user_id);
+SELECT create_distributed_table('registrations', 'user_id');
+
+CREATE TABLE IF NOT EXISTS recoveries
+(
+    user_id    BIGINT PRIMARY KEY,
+    token      VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_recoveries_user_id ON recoveries (user_id);
+CREATE INDEX IF NOT EXISTS idx_recoveries_token ON recoveries (token);
+SELECT create_distributed_table('recoveries', 'user_id');
+
+CREATE TABLE discriminators
+(
+    user_id       BIGINT NOT NULL,
+    discriminator TEXT   NOT NULL
+);
+CREATE INDEX idx_discriminator ON discriminators (discriminator);
+SELECT create_distributed_table('discriminators', 'discriminator');
+
+CREATE TABLE guilds
+(
+    id          BIGINT PRIMARY KEY,
+    name        TEXT        NOT NULL,
+    owner_id    BIGINT      NOT NULL,
+    icon        BIGINT,
+    public      BOOL        NOT NULL DEFAULT false,
+    permissions BIGINT      NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_guilds_id ON guilds (id);
+SELECT create_distributed_table('guilds', 'id');
+
+CREATE TABLE channels
+(
+    id           BIGINT PRIMARY KEY,
+    name         TEXT        NOT NULL,
+    type         INT         NOT NULL,
+    parent_id    BIGINT,
+    permissions  BIGINT,
+    topic        TEXT,
+    private      BOOL        NOT NULL,
+    last_message BIGINT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_channels_id ON channels (id);
+SELECT create_distributed_table('channels', 'id');
+
+CREATE TABLE guild_channels
+(
+    guild_id   BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    position   INT    NOT NULL
+);
+CREATE INDEX idx_guild_channels_ids ON guild_channels (guild_id, channel_id);
+SELECT create_distributed_table('guild_channels', 'guild_id');
+
+CREATE TABLE friends
+(
+    user_id    BIGINT      NOT NULL,
+    friend_id  BIGINT      NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_user_friend_ids ON friends (user_id, friend_id);
+SELECT create_distributed_table('friends', 'user_id');
+
+CREATE TABLE dm_channels
+(
+    user_id        BIGINT NOT NULL,
+    participant_id BIGINT NOT NULL,
+    channel_id     BIGINT NOT NULL
+);
+CREATE INDEX idx_dm_channel_id_user_id_participant_id ON dm_channels (user_id, participant_id, channel_id);
+CREATE UNIQUE INDEX idx_unique_dm_channel ON dm_channels (channel_id);
+SELECT create_distributed_table('dm_channels', 'channel_id');
+
+CREATE TABLE group_dm_channels
+(
+    channel_id BIGINT PRIMARY KEY,
+    user_id    BIGINT NOT NULL
+);
+CREATE INDEX idx_group_dm_channels ON group_dm_channels (channel_id);
+SELECT create_distributed_table('group_dm_channels', 'channel_id');
+
+CREATE TABLE members
+(
+    user_id  BIGINT      NOT NULL,
+    guild_id BIGINT      NOT NULL,
+    username TEXT,
+    avatar   BIGINT,
+    join_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    timeout  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_guild_members ON members (user_id, guild_id);
+SELECT create_distributed_table('members', 'guild_id');
+
+CREATE TABLE roles
+(
+    id          BIGINT NOT NULL,
+    guild_id    BIGINT NOT NULL,
+    name        TEXT   NOT NULL,
+    color       INT    NOT NULL,
+    permissions BIGINT NOT NULL
+);
+CREATE INDEX idx_roles_id_guild_id ON roles (id, guild_id);
+SELECT create_distributed_table('roles', 'guild_id');
+
+CREATE TABLE user_roles
+(
+    guild_id BIGINT NOT NULL,
+    user_id  BIGINT NOT NULL,
+    role_id  BIGINT NOT NULL
+);
+CREATE INDEX idx_user_roles ON user_roles (user_id, guild_id);
+SELECT create_distributed_table('user_roles', 'guild_id');
+
+CREATE TABLE channel_roles_permissions
+(
+    channel_id BIGINT NOT NULL,
+    role_id    BIGINT NOT NULL,
+    accept     BIGINT NOT NULL,
+    deny       BIGINT NOT NULL
+);
+CREATE INDEX idx_channel_roles_permission_ch_id_role_id ON channel_roles_permissions (channel_id, role_id);
+SELECT create_distributed_table('channel_roles_permissions', 'channel_id');
+
+CREATE TABLE channel_user_permissions
+(
+    channel_id BIGINT NOT NULL,
+    user_id    BIGINT NOT NULL,
+    accept     BIGINT NOT NULL,
+    deny       BIGINT NOT NULL
+);
+CREATE INDEX idx_channel_user_permission_ch_id_user_id ON channel_user_permissions (channel_id, user_id);
+SELECT create_distributed_table('channel_user_permissions', 'channel_id');
+
+CREATE TABLE audit
+(
+    guild_id   BIGINT      NOT NULL,
+    changes    JSONB       NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_audit_guild_id ON audit (guild_id);
+SELECT create_distributed_table('audit', 'guild_id');

--- a/helm/gochat/files/db/cassandra/000001_initial.down.cql
+++ b/helm/gochat/files/db/cassandra/000001_initial.down.cql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS gochat.messages;
+DROP TABLE IF EXISTS gochat.avatars;
+DROP TABLE IF EXISTS gochat.icons;
+DROP TABLE IF EXISTS gochat.attachments;
+DROP TABLE IF EXISTS gochat.reactions;

--- a/helm/gochat/files/db/cassandra/000001_initial.up.cql
+++ b/helm/gochat/files/db/cassandra/000001_initial.up.cql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS gochat.attachments
+(
+    id           bigint,
+    channel_id   bigint,
+    name         text,
+    filesize     bigint,
+    content_type text,
+    height       bigint,
+    width        bigint,
+    done         boolean,
+    PRIMARY KEY ( (channel_id), id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.icons
+(
+    id       bigint,
+    guild_id bigint,
+    object   text,
+    PRIMARY KEY ( guild_id, id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.avatars
+(
+    id      bigint,
+    user_id bigint,
+    object  text,
+    PRIMARY KEY ( user_id, id )
+);
+
+CREATE TABLE IF NOT EXISTS gochat.messages
+(
+    channel_id  bigint,
+    bucket      int,
+    id          bigint,
+    user_id     bigint,
+    content     text,
+    thread_id   bigint,
+    attachments list<bigint>,
+    type        int,
+    reference   bigint,
+    thread      bigint,
+    edited_at   timestamp,
+    PRIMARY KEY ( (channel_id, bucket), id )
+) WITH CLUSTERING ORDER BY (id DESC);
+
+CREATE TABLE IF NOT EXISTS gochat.reactions
+(
+    message_id bigint,
+    user_id    bigint,
+    emote_id   bigint,
+    PRIMARY KEY ( message_id, user_id )
+);

--- a/helm/gochat/files/db/postgres/000001_initial.down.sql
+++ b/helm/gochat/files/db/postgres/000001_initial.down.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS audit;
+DROP TABLE IF EXISTS channel_user_permissions;
+DROP TABLE IF EXISTS channel_roles_permissions;
+DROP TABLE IF EXISTS user_roles;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS members;
+DROP TABLE IF EXISTS group_dm_channels;
+DROP TABLE IF EXISTS dm_channels;
+DROP TABLE IF EXISTS friends;
+DROP TABLE IF EXISTS guild_channels;
+DROP TABLE IF EXISTS channels;
+DROP TABLE IF EXISTS guilds;
+DROP TABLE IF EXISTS discriminators;
+DROP TABLE IF EXISTS registrations;
+DROP TABLE IF EXISTS authentications;
+DROP TABLE IF EXISTS users;

--- a/helm/gochat/files/db/postgres/000001_initial.up.sql
+++ b/helm/gochat/files/db/postgres/000001_initial.up.sql
@@ -1,0 +1,178 @@
+CREATE EXTENSION IF NOT EXISTS citus;
+
+CREATE TABLE users
+(
+    id           BIGINT PRIMARY KEY,
+    name         TEXT        NOT NULL,
+    avatar       BIGINT,
+    blocked      BOOL        NOT NULL,
+    upload_limit BIGINT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_users_id_name ON users (id, name);
+SELECT create_distributed_table('users', 'id');
+
+CREATE TABLE authentications
+(
+    user_id       BIGINT      NOT NULL,
+    email         TEXT        NOT NULL,
+    password_hash TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_authentication_id_email ON authentications (user_id, email);
+SELECT create_distributed_table('authentications', 'user_id');
+
+CREATE TABLE registrations
+(
+    user_id            BIGINT PRIMARY KEY,
+    email              TEXT        NOT NULL,
+    confirmation_token TEXT        NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_registration_user_id ON registrations (user_id);
+SELECT create_distributed_table('registrations', 'user_id');
+
+CREATE TABLE IF NOT EXISTS recoveries
+(
+    user_id    BIGINT PRIMARY KEY,
+    token      VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_recoveries_user_id ON recoveries (user_id);
+CREATE INDEX IF NOT EXISTS idx_recoveries_token ON recoveries (token);
+SELECT create_distributed_table('recoveries', 'user_id');
+
+CREATE TABLE discriminators
+(
+    user_id       BIGINT NOT NULL,
+    discriminator TEXT   NOT NULL
+);
+CREATE INDEX idx_discriminator ON discriminators (discriminator);
+SELECT create_distributed_table('discriminators', 'discriminator');
+
+CREATE TABLE guilds
+(
+    id          BIGINT PRIMARY KEY,
+    name        TEXT        NOT NULL,
+    owner_id    BIGINT      NOT NULL,
+    icon        BIGINT,
+    public      BOOL        NOT NULL DEFAULT false,
+    permissions BIGINT      NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_guilds_id ON guilds (id);
+SELECT create_distributed_table('guilds', 'id');
+
+CREATE TABLE channels
+(
+    id           BIGINT PRIMARY KEY,
+    name         TEXT        NOT NULL,
+    type         INT         NOT NULL,
+    parent_id    BIGINT,
+    permissions  BIGINT,
+    topic        TEXT,
+    private      BOOL        NOT NULL,
+    last_message BIGINT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_channels_id ON channels (id);
+SELECT create_distributed_table('channels', 'id');
+
+CREATE TABLE guild_channels
+(
+    guild_id   BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    position   INT    NOT NULL
+);
+CREATE INDEX idx_guild_channels_ids ON guild_channels (guild_id, channel_id);
+SELECT create_distributed_table('guild_channels', 'guild_id');
+
+CREATE TABLE friends
+(
+    user_id    BIGINT      NOT NULL,
+    friend_id  BIGINT      NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_user_friend_ids ON friends (user_id, friend_id);
+SELECT create_distributed_table('friends', 'user_id');
+
+CREATE TABLE dm_channels
+(
+    user_id        BIGINT NOT NULL,
+    participant_id BIGINT NOT NULL,
+    channel_id     BIGINT NOT NULL
+);
+CREATE INDEX idx_dm_channel_id_user_id_participant_id ON dm_channels (user_id, participant_id, channel_id);
+CREATE UNIQUE INDEX idx_unique_dm_channel ON dm_channels (channel_id);
+SELECT create_distributed_table('dm_channels', 'channel_id');
+
+CREATE TABLE group_dm_channels
+(
+    channel_id BIGINT PRIMARY KEY,
+    user_id    BIGINT NOT NULL
+);
+CREATE INDEX idx_group_dm_channels ON group_dm_channels (channel_id);
+SELECT create_distributed_table('group_dm_channels', 'channel_id');
+
+CREATE TABLE members
+(
+    user_id  BIGINT      NOT NULL,
+    guild_id BIGINT      NOT NULL,
+    username TEXT,
+    avatar   BIGINT,
+    join_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    timeout  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_guild_members ON members (user_id, guild_id);
+SELECT create_distributed_table('members', 'guild_id');
+
+CREATE TABLE roles
+(
+    id          BIGINT NOT NULL,
+    guild_id    BIGINT NOT NULL,
+    name        TEXT   NOT NULL,
+    color       INT    NOT NULL,
+    permissions BIGINT NOT NULL
+);
+CREATE INDEX idx_roles_id_guild_id ON roles (id, guild_id);
+SELECT create_distributed_table('roles', 'guild_id');
+
+CREATE TABLE user_roles
+(
+    guild_id BIGINT NOT NULL,
+    user_id  BIGINT NOT NULL,
+    role_id  BIGINT NOT NULL
+);
+CREATE INDEX idx_user_roles ON user_roles (user_id, guild_id);
+SELECT create_distributed_table('user_roles', 'guild_id');
+
+CREATE TABLE channel_roles_permissions
+(
+    channel_id BIGINT NOT NULL,
+    role_id    BIGINT NOT NULL,
+    accept     BIGINT NOT NULL,
+    deny       BIGINT NOT NULL
+);
+CREATE INDEX idx_channel_roles_permission_ch_id_role_id ON channel_roles_permissions (channel_id, role_id);
+SELECT create_distributed_table('channel_roles_permissions', 'channel_id');
+
+CREATE TABLE channel_user_permissions
+(
+    channel_id BIGINT NOT NULL,
+    user_id    BIGINT NOT NULL,
+    accept     BIGINT NOT NULL,
+    deny       BIGINT NOT NULL
+);
+CREATE INDEX idx_channel_user_permission_ch_id_user_id ON channel_user_permissions (channel_id, user_id);
+SELECT create_distributed_table('channel_user_permissions', 'channel_id');
+
+CREATE TABLE audit
+(
+    guild_id   BIGINT      NOT NULL,
+    changes    JSONB       NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_audit_guild_id ON audit (guild_id);
+SELECT create_distributed_table('audit', 'guild_id');

--- a/helm/gochat/templates/migrations-configmap.yaml
+++ b/helm/gochat/templates/migrations-configmap.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gochat.fullname" . }}-migration-script
+  labels:
+    {{- include "gochat.componentLabels" (dict "Context" . "Component" "migrations") | nindent 4 }}
+data:
+  run-migrations.sh: |-
+    #!/usr/bin/env sh
+    set -eu
+
+    if [ -z "${PG_ADDRESS:-}" ] && [ -z "${CASSANDRA_ADDRESS:-}" ]; then
+      echo "PG_ADDRESS or CASSANDRA_ADDRESS must be provided" >&2
+      exit 1
+    fi
+
+    apk add --no-cache ca-certificates git build-base >/dev/null
+
+    go install -tags "postgres cassandra" github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+
+    MIGRATE_BIN="$(go env GOPATH)/bin/migrate"
+
+    if [ -n "${PG_ADDRESS:-}" ]; then
+      ${MIGRATE_BIN} -database "${PG_ADDRESS}" -path /migrations/postgres up
+    else
+      echo "Skipping PostgreSQL migrations because PG_ADDRESS is empty"
+    fi
+
+    if [ -n "${CASSANDRA_ADDRESS:-}" ]; then
+      ${MIGRATE_BIN} -database "${CASSANDRA_ADDRESS}" -path /migrations/cassandra up
+    else
+      echo "Skipping Scylla migrations because CASSANDRA_ADDRESS is empty"
+    fi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gochat.fullname" . }}-migrations
+  labels:
+    {{- include "gochat.componentLabels" (dict "Context" . "Component" "migrations") | nindent 4 }}
+data:
+{{- range $path, $file := .Files.Glob "files/db/postgres/*" }}
+  postgres/{{ base $path }}: |-
+{{ $file | indent 4 }}
+{{- end }}
+{{- range $path, $file := .Files.Glob "files/db/cassandra/*" }}
+  cassandra/{{ base $path }}: |-
+{{ $file | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/gochat/templates/migrations-job.yaml
+++ b/helm/gochat/templates/migrations-job.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "gochat.fullname" . }}-migrations
+  labels:
+    {{- include "gochat.componentLabels" (dict "Context" . "Component" "migrations") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 5 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gochat.componentSelectorLabels" (dict "Context" . "Component" "migrations") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $defaultPg := "" -}}
+      {{- if .Values.citus.enabled -}}
+        {{- $defaultPg = printf "postgres://%s@%s-citus-master:%d/%s?sslmode=disable" .Values.citus.auth.postgresUser (include "gochat.fullname" .) .Values.citus.master.service.port .Values.citus.auth.postgresDb -}}
+      {{- end -}}
+      {{- $defaultCassandra := "" -}}
+      {{- if .Values.scylla.enabled -}}
+        {{- $defaultCassandra = printf "cassandra://%s-scylla:%d/%s?x-multi-statement=true" (include "gochat.fullname" .) .Values.scylla.service.ports.cql .Values.scylla.lifecycle.createKeyspace.keyspace -}}
+      {{- end -}}
+      containers:
+        - name: migrations
+          image: "{{ .Values.migrations.image.repository }}:{{ .Values.migrations.image.tag }}"
+          imagePullPolicy: {{ .Values.migrations.image.pullPolicy }}
+          command: ["/bin/sh", "/scripts/run-migrations.sh"]
+          env:
+            - name: PG_ADDRESS
+              value: {{ default $defaultPg .Values.migrations.pgAddress | quote }}
+            - name: CASSANDRA_ADDRESS
+              value: {{ default $defaultCassandra .Values.migrations.cassandraAddress | quote }}
+          volumeMounts:
+            - name: migrate-script
+              mountPath: /scripts/run-migrations.sh
+              subPath: run-migrations.sh
+            - name: migrations
+              mountPath: /migrations
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+      volumes:
+        - name: migrate-script
+          configMap:
+            name: {{ include "gochat.fullname" . }}-migration-script
+            defaultMode: 0555
+        - name: migrations
+          configMap:
+            name: {{ include "gochat.fullname" . }}-migrations
+      {{- with .Values.migrations.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrations.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrations.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/gochat/values.yaml
+++ b/helm/gochat/values.yaml
@@ -425,6 +425,20 @@ ui:
   tolerations: []
   affinity: {}
 
+migrations:
+  enabled: true
+  image:
+    repository: golang
+    tag: 1.23-alpine
+    pullPolicy: IfNotPresent
+  pgAddress: ""
+  cassandraAddress: ""
+  backoffLimit: 5
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 opensearch:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
## Summary
- add a configurable UI image so the new landing container can replace the full client when desired
- vendor PostgreSQL and Scylla migration files and run them automatically in Docker Compose through a dedicated one-shot service
- package the same migrations in the Helm chart and execute them with a post-install/upgrade job

## Testing
- not run (helm binary unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68cb984d12508322a606d394db67153e