### PR TITLE
Add PUBLIC_BASE_PATH configuration

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -74,6 +74,7 @@ services:
     environment:
       PUBLIC_WS_URL: "${PUBLIC_WS_URL:-https://example.com}"
       PUBLIC_API_BASE_URL: "${PUBLIC_API_BASE_URL:-https://example.com}"
+      PUBLIC_BASE_PATH: "${PUBLIC_BASE_PATH:-/}"
     networks:
       - traefik
       - default

--- a/docs/compose-environment.md
+++ b/docs/compose-environment.md
@@ -6,6 +6,7 @@ The Docker Compose stack relies on a mix of environment variables with sensible 
 
 - `PUBLIC_WS_URL` – Public WebSocket endpoint served by Traefik. Use the externally reachable `wss://` or `https://` origin for the `/ws` route so the UI can establish realtime connections.
 - `PUBLIC_API_BASE_URL` – Public HTTPS endpoint for the REST API. The value must match the domain (and optional base path) exposed by Traefik for `/api/v1`.
+- `PUBLIC_BASE_PATH` – Base pathname where the UI is mounted. Defaults to `/`, but update it when serving the SPA from a subdirectory so client-side routing generates correct links.
 
 ## Optional variables
 

--- a/helm/gochat/values.yaml
+++ b/helm/gochat/values.yaml
@@ -420,6 +420,7 @@ ui:
   env:
     PUBLIC_WS_URL: "https://example.com"
     PUBLIC_API_BASE_URL: "https://example.com"
+    PUBLIC_BASE_PATH: "/"
   resources: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## Summary
- add PUBLIC_BASE_PATH to the UI service in docker-compose and document it for Compose users
- expose the same PUBLIC_BASE_PATH default in Helm values so the deployment template renders the new key

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccec229b40832287b326fd1fa4b0a2